### PR TITLE
[FTR] BKHV-13 | Add AutoMapper dependency and profile configuration

### DIFF
--- a/BookHiveDB.Web/AutoMapper/BookHiveAutoMapperProfile.cs
+++ b/BookHiveDB.Web/AutoMapper/BookHiveAutoMapperProfile.cs
@@ -8,6 +8,6 @@ public class BookHiveAutoMapperProfile : Profile
 {
     public BookHiveAutoMapperProfile()
     {
-        CreateMap<Author, AuthorDTO>();
+        
     }
 }

--- a/BookHiveDB.Web/AutoMapper/BookHiveAutoMapperProfile.cs
+++ b/BookHiveDB.Web/AutoMapper/BookHiveAutoMapperProfile.cs
@@ -1,0 +1,13 @@
+﻿using AutoMapper;
+using BookHiveDB.Domain.DomainModels;
+using BookHiveDB.Domain.DTO.REST;
+
+namespace BookHiveDB.Web.AutoMapper;
+
+public class BookHiveAutoMapperProfile : Profile
+{
+    public BookHiveAutoMapperProfile()
+    {
+        CreateMap<Author, AuthorDTO>();
+    }
+}

--- a/BookHiveDB.Web/BookHiveDB.Web.csproj
+++ b/BookHiveDB.Web/BookHiveDB.Web.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="ClosedXML" Version="0.102.0" />
     <PackageReference Include="ExcelDataReader" Version="3.6.0" />
     <PackageReference Include="GemBox.Document" Version="35.0.1403" />

--- a/BookHiveDB.Web/Program.cs
+++ b/BookHiveDB.Web/Program.cs
@@ -24,6 +24,8 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 
 builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseNpgsql(connectionString));
 
+builder.Services.AddAutoMapper(typeof(Program).Assembly);
+
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
 builder.Services


### PR DESCRIPTION
This PR adds AutoMapper to the project.

AutoMapper is an auto mapping library that helps us easily map domain entities to DTOs and vice-versa. It has more powerful capabilities, but the basic one is all we need.

In the `BookHiveAutoMapperProfile` is where we would write our mapping configurations. I'll explain this in our next meeting.